### PR TITLE
Update 01_hhchar.do

### DIFF
--- a/Stata/01_hhchar.do
+++ b/Stata/01_hhchar.do
@@ -124,6 +124,9 @@ g byte under15t = b1_02<15
 egen under15 = total(under15t), by(a01)
 la var under15 "number of hh members under 15"
 egen under15male = total(under15t) if male==1, by(a01)
+egen under15male_r = max(under15male), by(a01) //ac
+replace under15male = under15male_r //ac
+drop under15male_r //ac
 la var under15male "number of hh male members under 15"
 recode under15male (. = 0) if under15male==.
 
@@ -131,6 +134,9 @@ recode under15male (. = 0) if under15male==.
 g byte under24t = b1_02<24
 egen under24 = total(under24t), by(a01)
 egen under24male = total(under24t) if male==1, by(a01)
+egen under24male_r = max(under24male), by(a01) //ac
+replace under24male = under24male_r //ac
+drop under24male_r //ac
 recode under24male (. = 0) if under24male==.
 la var under24 "number of hh members under 24"
 la var under24male "number of hh male members under 24"
@@ -188,6 +194,9 @@ replace educ = 6 if inlist(b1_08, 76)
 
 * Create variable reflect the max education in the household for those 25+
 egen educAdult = max(educ) if b1_02>24, by(a01)
+egen educAdult_r = max(educAdult), by(a01) //ac
+replace educAdult = educAdult_r  //ac
+drop educAdult_r  //ac
 
 g educHoh = educ if hoh==1
 la var educAdult "Highest adult education in household"


### PR DESCRIPTION
Issues
1)
- affected variables - under15male, under24male, educAdult
- issue - variables created using "...max(x)" led to missing values for HH 
- resolution - replaced all with HH levels
  2)
- affected variable - depRatio
- issue - double checking age used in calculation (60 or 64): text description says "[(# people 0-14 + those 65+) / # people aged 15-64 ] \* 100" and "The dependency ratio is defined as the ratio of the number of members in the age groups of 0–14 years and above 60 years to the number of members of working age (15–60 years)" & gen cmd is "g byte numDepRatio = (b1_02<15 | b1_02>60)"
- resolution - left unchanged (age kept at 60)

3) 
-affected variable - hhlabor, mlabor, flabor
- issue - disconnect between label and formula; double check min age; label - la var hhlabor "hh labor age>11 & < 60" and formula - "g byte hhLabort = (b1_02>= 15 & b1_02<60)"
